### PR TITLE
allow higher than rand 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ categories = ["network-programming"]
 license = "Unlicense"
 
 [dependencies]
-rand = "0.6"
+rand = ">= 0.6"


### PR DESCRIPTION
this is needed to have better dependency management in the future.
Alot of crates depend on this.
But portpicker using 0.6 and NOT 0.7 will mean for alot of rust programs to include both.
Which increases the compile time for some projects.
So in order to be future prof we should change it to >= 0.6, so it will accept newer too without recent updates necessary.

Best regards,
Marcel